### PR TITLE
Fix an wrong copy destination.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,7 +103,7 @@ RUN sed -i -e s/\"channels_last\"/\"channels_first\"/ ~/.keras/keras.json && \
 
 
 
-ADD theanorc /home/keras/.theanorc
+ADD theanorc /home/kocr/.theanorc
 
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8


### PR DESCRIPTION
Dear team,

I've found one trivial issue on `Dockerfile`. Because `kocr` user is made during the build process and the default user is `kocr`, `.theanorc` file should be located at `/home/kocr`. Not `/home/keras`.
This difference might cause Theano can't use GPU in default configuration.

If this modification isn't good, please ignore it...

Thanks!