### PR TITLE
Set default theano configuration and trivial fixes.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,7 +103,7 @@ RUN sed -i -e s/\"channels_last\"/\"channels_first\"/ ~/.keras/keras.json && \
 
 
 
-ADD theanorc /home/keras/.theanorc
+ADD theanorc /home/kocr/.theanorc
 
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@ help:
 	@cat Makefile
 
 DATA?="${HOME}/Data"
-GPU?=0
+DEVICES?=--gpus=all
 DOCKER_FILE=Dockerfile
-DOCKER=GPU=$(GPU) docker
+DOCKER=docker
 BACKEND?=theano
 PYTHON_VERSION?=3.6
 CUDA_VERSION?=10.1
@@ -15,11 +15,11 @@ SRC?=$(shell dirname `pwd`)
 
 
 build:
-	docker build -t keras --build-arg python_version=$(PYTHON_VERSION) --build-arg cuda_version=$(CUDA_VERSION) --build-arg cudnn_version=$(CUDNN_VERSION) --build-arg theano_version=$(THEANO_VERSION) -f $(DOCKER_FILE) .
+	$(DOCKER) build -t keras --build-arg python_version=$(PYTHON_VERSION) --build-arg cuda_version=$(CUDA_VERSION) --build-arg cudnn_version=$(CUDNN_VERSION) --build-arg theano_version=$(THEANO_VERSION) -f $(DOCKER_FILE) .
 
 bash: build
 	$(DOCKER) run \
-        -it --gpus all -v $(SRC):/src/workspace -v $(DATA):/data --env KERAS_BACKEND=$(BACKEND) keras bash
+        -it $(DEVICES) -v $(SRC):/src/workspace -v $(DATA):/data --env KERAS_BACKEND=$(BACKEND) keras bash
 
 ipython: build
 	$(DOCKER) run $(DEVICES) $(CUDA_LIB) $(CUDA_SO) -it -v $(SRC):/src/workspace -v $(DATA):/data --env KERAS_BACKEND=$(BACKEND) keras ipython

--- a/theanorc
+++ b/theanorc
@@ -1,5 +1,5 @@
 [global]
 floatX = float32
-optimizer=None
+mode = FAST_RUN
 device = cuda
 


### PR DESCRIPTION
Dear team,

This PR includes:
* fix wrong destination to copy `theanorc` from host into container,
* fix unexpected theano configuration for theano's compile optimization option,
* fix inconsistent docker command itself and device option.

This makes users to be able to use training script more easily.
