### PR TITLE
Fix accidentally joining two paths without separator.

### DIFF
--- a/train_cnn.py
+++ b/train_cnn.py
@@ -32,7 +32,7 @@ def load_data(input_dirs, nb_dim, pad=3):
         for name in os.listdir(input_dir):
             if not name.endswith('.png'):
                 continue
-            img = cv.imread(input_dir + name, 0)
+            img = cv.imread(os.path.join(input_dir, name), 0)
 
             # Thresholding
             img = cv.threshold(img, 255 * 0.7, 255, cv.THRESH_BINARY_INV)[1]


### PR DESCRIPTION
Dear team,

Currently, we might face one issue that `train_cnn.py` fails to load image data when we give image directory option without last separator (`/`) like below. This PR solves the issue.

```
python train_cnn.py --train_dirs ../images/numbers --test_dirs ../images/samples/
```
